### PR TITLE
feat(review): 提升文件差异审查的渲染能力

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -78,6 +78,9 @@ export default defineConfig({
       }
     },
     plugins: [react()],
+    worker: {
+      format: 'es'
+    },
     server: {
       host: '127.0.0.1'
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@astryxdesign/core": "^0.2.0",
         "@astryxdesign/theme-neutral": "^0.2.0",
+        "@pierre/diffs": "1.2.12",
         "@tanstack/react-virtual": "^3.14.5",
         "@vscode/ripgrep": "^1.18.0",
         "better-sqlite3": "^11.9.1",
@@ -2563,6 +2564,64 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/@pierre/diffs": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.2.12.tgz",
+      "integrity": "sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ==",
+      "license": "apache-2.0",
+      "dependencies": {
+        "@pierre/theme": "1.1.0",
+        "@pierre/theming": "0.0.2",
+        "@shikijs/transformers": "^3.0.0 || ^4.0.0",
+        "diff": "9.0.0",
+        "hast-util-to-html": "9.0.5",
+        "lru_map": "0.4.1",
+        "shiki": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/@pierre/theme": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-1.1.0.tgz",
+      "integrity": "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ==",
+      "license": "MIT",
+      "engines": {
+        "vscode": "^1.0.0"
+      }
+    },
+    "node_modules/@pierre/theming": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@pierre/theming/-/theming-0.0.2.tgz",
+      "integrity": "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw==",
+      "license": "apache-2.0",
+      "peerDependencies": {
+        "@pierre/theme": "^1.1.0",
+        "@shikijs/themes": "^3.0.0 || ^4.0.0",
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0",
+        "shiki": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@pierre/theme": {
+          "optional": true
+        },
+        "@shikijs/themes": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "shiki": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2931,6 +2990,119 @@
         "win32"
       ]
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.2.tgz",
+      "integrity": "sha512-StyzbAyxg2/tBGf78gwbBkGyeQ73lf8UiJArFaQhTQIDqQOCKPCQFanvrs4/Yv3Yfyc+ONInJM6K+FMIf+P+kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.4.2",
+        "@shikijs/types": "4.4.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.2.tgz",
+      "integrity": "sha512-MnIkeqWdVPUWsxlx8gKLVCJFTsqrQJgpTPBPpQwaFeJ56lOnJxj5aN2LUFnfxUEcvOQuNocmbaMnVrCEln6rkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.2.tgz",
+      "integrity": "sha512-GLhowz1+jixjz+wiZ3wMnOn1jTxiFCGl2PkXufivbnwPHKuyw1AYqu5/hbWhZZ2oAb0NP05WUJhYeigY14drnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.2.tgz",
+      "integrity": "sha512-8DfeusD+Zdv/eYIDdXyJTUnSMHt+aAWjAOCXV20HNGAHRlInXpG8wh421v6B91WOm9TFwRLN+b/LG5F2NAIojg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.2.tgz",
+      "integrity": "sha512-l6fQQKsOMlz72n38fztmSgZ76MO6KSWuw8o+GJ+FhmqrpC9pIOJNQNXGgbb5yX2AwpzlEHwsaLPnk/8o4Fm+rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.2.tgz",
+      "integrity": "sha512-H0CFoL07ddDC2Dd6EdrPYNkRhUR6YCkJlnuYFceYYUJJA5TIm2b5B33qqiDYryBExgbKMndFJPb2u1gTuqO37g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.4.2.tgz",
+      "integrity": "sha512-d81PJ9KkR1tVP95FH/9296HTtDo0mh76wv10u9T1YmsZq/UcXgt0OLdBszfUQ1i+umkRMCjDnFbFZU7/tCODTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.4.2",
+        "@shikijs/types": "4.4.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.2.tgz",
+      "integrity": "sha512-PFYitV4vpDr/iPCIhnHp+Q4ftic5N5VeNJ3KQ1O8gn3h2ar8qgwMAXF7tq4m1CWaMS60fV4VqF6vfnWH4F7vqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -3101,6 +3273,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -3116,6 +3297,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/ms": {
@@ -3177,6 +3367,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/verror": {
       "version": "1.10.11",
       "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
@@ -3194,6 +3390,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -4546,6 +4748,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -4578,6 +4790,26 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-error": {
@@ -4809,6 +5041,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -5217,6 +5459,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -5234,12 +5485,34 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dir-compare": {
       "version": "4.2.0",
@@ -6823,6 +7096,42 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -6867,6 +7176,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -7676,6 +7995,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -7843,6 +8168,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -7852,6 +8198,95 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -8429,6 +8864,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/ora": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
@@ -8970,6 +9422,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -9180,6 +9642,30 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -9662,6 +10148,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.2.tgz",
+      "integrity": "sha512-P8F/dFhRevaw2uSdeIYlq/5SXZNY85DPtmXQ947gD1Zj2JqO5AkNvVVBar0Me9JkFx3uzVud/qOtP5ek9NEQGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.4.2",
+        "@shikijs/engine-javascript": "4.4.2",
+        "@shikijs/engine-oniguruma": "4.4.2",
+        "@shikijs/langs": "4.4.2",
+        "@shikijs/themes": "4.4.2",
+        "@shikijs/types": "4.4.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -9848,6 +10353,16 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -9931,6 +10446,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -10418,6 +10947,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -10514,6 +11053,74 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -10601,6 +11208,34 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -11201,6 +11836,16 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@astryxdesign/core": "^0.2.0",
     "@astryxdesign/theme-neutral": "^0.2.0",
+    "@pierre/diffs": "1.2.12",
     "@tanstack/react-virtual": "^3.14.5",
     "@vscode/ripgrep": "^1.18.0",
     "better-sqlite3": "^11.9.1",

--- a/src/renderer/features/diff/diffLines.css
+++ b/src/renderer/features/diff/diffLines.css
@@ -1,5 +1,3 @@
-/* 共享 diff 行 / hunk 渲染样式（DiffViewer 与 Inspector 共用） */
-
 .diff-file__body {
   background-color: #fafaf7;
   min-width: 0;
@@ -16,139 +14,25 @@
   border-top: none;
 }
 
-.diff-hunk__header {
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  padding: 4px 14px;
-  background-color: var(--bg-sand);
-  border-bottom: 1px solid var(--border-cream);
-}
-
-.diff-hunk__content {
-  margin: 0;
-  padding: 0;
-  font-family: var(--font-mono);
-  font-size: 0.8rem;
-  line-height: 1.5;
-  overflow-x: auto;
-  max-width: 100%;
-}
-
-.diff-hunk__content--wrap {
-  overflow-x: hidden;
-}
-
-.diff-line {
-  display: flex;
-  width: max-content;
-  min-width: 100%;
-  min-height: 22px;
-}
-
-/* 虚拟化行：高度严格锁定为 DIFF_LINE_HEIGHT_PX，避免行内容溢出破坏滚动对齐 */
-.diff-hunk__virtual .diff-line {
-  height: 22px;
-  min-height: 22px;
+.diff-hunk--pierre {
   overflow: hidden;
 }
 
-.diff-hunk__content--wrap .diff-line {
+.nova-pierre-diff {
+  display: block;
   width: 100%;
-}
-
-.diff-line__no {
-  display: inline-block;
-  width: 40px;
-  text-align: right;
-  padding-right: 8px;
-  color: var(--text-muted);
-  background-color: rgba(0, 0, 0, 0.03);
-  user-select: none;
-  flex-shrink: 0;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  padding-top: 1px;
-}
-
-.diff-line__text {
-  padding-left: 8px;
-  padding-right: 14px;
-  white-space: pre;
-  flex: 1 0 auto;
   min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
 }
 
-.diff-line__text--wrap {
-  white-space: pre-wrap;
-  word-break: break-word;
-  flex: 1 1 auto;
-}
-
-.diff-line__prefix {
+.diff-hunk__pending {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
   color: var(--text-muted);
-}
-
-.diff-token--plain {
-  color: inherit;
-}
-
-.diff-token--comment {
-  color: #667a63;
-  font-style: italic;
-}
-
-.diff-token--string {
-  color: #8f4e1f;
-}
-
-.diff-token--number {
-  color: #1f5d75;
-}
-
-.diff-token--keyword {
-  color: #7a2f54;
-  font-weight: 600;
-}
-
-.diff-token--operator {
-  color: #6f5c4b;
-}
-
-.diff-token--property {
-  color: #2f5f7a;
-}
-
-.diff-line--add {
-  background-color: rgba(120, 140, 93, 0.1);
-}
-
-.diff-line--add .diff-line__text {
-  color: #3d5a1e;
-}
-
-.diff-line--add .diff-line__no {
-  background-color: rgba(120, 140, 93, 0.06);
-}
-
-.diff-line--remove {
-  background-color: rgba(181, 51, 51, 0.08);
-}
-
-.diff-line--remove .diff-line__text {
-  color: #8b2020;
-}
-
-.diff-line--remove .diff-line__no {
-  background-color: rgba(181, 51, 51, 0.04);
-}
-
-.diff-line--context {
-  background-color: transparent;
-}
-
-.diff-line--context .diff-line__text {
-  color: var(--text-primary);
+  font-size: 0.75rem;
+  background-color: var(--bg-sand);
 }
 
 .diff-hunk__truncation {
@@ -174,3 +58,11 @@
 .diff-file__changes-del {
   color: var(--color-error);
 }
+
+.diff-token--plain { color: inherit; }
+.diff-token--comment { color: var(--code-token-comment); font-style: italic; }
+.diff-token--string { color: var(--code-token-string); }
+.diff-token--number { color: var(--code-token-number); }
+.diff-token--keyword { color: var(--code-token-keyword); font-weight: 600; }
+.diff-token--operator { color: var(--code-token-operator); }
+.diff-token--property { color: var(--code-token-property); }

--- a/src/renderer/features/diff/diffLines.tsx
+++ b/src/renderer/features/diff/diffLines.tsx
@@ -1,89 +1,55 @@
-/**
- * 共享 diff 行 / hunk 渲染（DiffViewer 与 Inspector ReviewTab 共用）。
- * 大 hunk 走虚拟化（只渲染可见窗口），避免几千行 diff 全量挂载阻塞主线程。
- */
-import React, { useMemo, useState } from 'react'
-import { useVirtualizer } from '@tanstack/react-virtual'
+import React, { useEffect, useMemo, useState } from 'react'
+import {
+  DEFAULT_VIRTUAL_FILE_METRICS,
+  type FileDiffOptions,
+  type VirtualFileMetrics,
+  type Virtualizer
+} from '@pierre/diffs'
+import { PatchDiff, VirtualizerContext } from '@pierre/diffs/react'
 import { Button } from '@astryxdesign/core/Button'
 import type { DiffEntry, DiffHunk } from '../../../shared/diff/types'
-import { highlightLine } from './syntaxHighlight'
-import { highlightLineCached } from '../../lib/highlightCache'
+import { buildHunkPatch } from './pierrePatch'
+import { acquirePierreVirtualizer } from './pierreVirtualizer'
 import './diffLines.css'
 
-/** 单个 hunk 超过此行数时截断展示 */
 export const PREVIEW_HUNK_LINE_LIMIT = 500
+export const LARGE_PATCH_CHAR_THRESHOLD = 500_000
+export const MAX_TOKENIZED_LINE_LENGTH = 1000
 
-/** 超过此行数的大 hunk 启用虚拟化（只渲染可见窗口） */
-export const VIRTUALIZE_HUNK_LINE_THRESHOLD = 80
-
-/** diff 行固定高度（px），虚拟化 estimateSize 用；与 .diff-line 的 min-height 对齐 */
-export const DIFF_LINE_HEIGHT_PX = 22
-
-/** 虚拟化 overscan（上下各多渲染的行数） */
-const VIRTUAL_OVERSCAN = 10
-
-export interface DiffLineViewProps {
-  prefix: string
-  text: string
-  realLineNo: number
-  filePath: string
-  /** 默认开启语法高亮；文本模式关闭 */
-  syntaxHighlight?: boolean
-  wrap?: boolean
+const DIFF_METRICS: VirtualFileMetrics = {
+  ...DEFAULT_VIRTUAL_FILE_METRICS,
+  lineHeight: 22,
+  hunkSeparatorHeight: 24,
+  spacing: 0
 }
 
-/** 单行 diff 渲染 */
-export const DiffLineView: React.FC<DiffLineViewProps> = ({
-  prefix,
-  text,
-  realLineNo,
-  filePath,
-  syntaxHighlight = true,
-  wrap = false
-}) => {
-  const type = prefix === '+' ? 'add' : prefix === '-' ? 'remove' : 'context'
-  const tokens = syntaxHighlight ? highlightLineCached(text, filePath, highlightLine) : null
+const PIERRE_CSS = `
+:host {
+  --diffs-font-family: var(--font-mono);
+  --diffs-font-size: 0.8rem;
+  --diffs-line-height: 22px;
+}
+`
 
-  return (
-    <div className={`diff-line diff-line--${type}`}>
-      <span className="diff-line__no">{realLineNo || ''}</span>
-      <span className={`diff-line__text${wrap ? ' diff-line__text--wrap' : ''}`}>
-        <span className="diff-line__prefix">{prefix}</span>
-        {tokens
-          ? tokens.map((token, idx) => (
-              <span key={idx} className={`diff-token diff-token--${token.type}`}>{token.text}</span>
-            ))
-          : text}
-      </span>
-    </div>
-  )
+export interface DiffRenderPolicy {
+  disableWorkerPool: boolean
+  lineDiffType: 'none' | 'word-alt'
+  maxLineDiffLength: number
+  tokenizeMaxLineLength: number
 }
 
-/** 预计算单行 diff 信息，避免渲染时依赖递增状态 */
-export interface ComputedDiffLine {
-  prefix: string
-  text: string
-  realLineNo: number
-}
+export function selectDiffRenderPolicy(
+  patchLength: number,
+  syntaxHighlight: boolean
+): DiffRenderPolicy {
+  const plainText = !syntaxHighlight || patchLength > LARGE_PATCH_CHAR_THRESHOLD
 
-/** 从 hunk content 预计算所有行的 diff 信息 */
-export function computeDiffLines(hunk: DiffHunk): ComputedDiffLine[] {
-  const lines = hunk.content.split('\n')
-  let oldLine = hunk.oldStart
-  let newLine = hunk.newStart
-  return lines.map(line => {
-    const prefix = line[0] || ' '
-    const text = line.slice(1)
-    let lineNo = 0
-    if (prefix === ' ') {
-      lineNo = oldLine; oldLine++; newLine++
-    } else if (prefix === '+') {
-      lineNo = newLine; newLine++
-    } else {
-      lineNo = oldLine; oldLine++
-    }
-    return { prefix, text, realLineNo: lineNo }
-  })
+  return {
+    disableWorkerPool: plainText,
+    lineDiffType: plainText ? 'none' : 'word-alt',
+    maxLineDiffLength: plainText ? 0 : MAX_TOKENIZED_LINE_LENGTH,
+    tokenizeMaxLineLength: plainText ? 0 : MAX_TOKENIZED_LINE_LENGTH
+  }
 }
 
 export interface HunkViewProps {
@@ -91,92 +57,9 @@ export interface HunkViewProps {
   filePath: string
   syntaxHighlight?: boolean
   wrap?: boolean
-  /** 外层滚动容器；大 hunk 虚拟化时使用（保证多 hunk 共用同一滚动条） */
   scrollRef?: React.RefObject<HTMLDivElement | null>
 }
 
-/** 单行渲染（虚拟化行共用，纯展示） */
-const DiffLineViewInner: React.FC<{
-  line: ComputedDiffLine
-  filePath: string
-  syntaxHighlight: boolean
-  wrap: boolean
-}> = ({ line, filePath, syntaxHighlight, wrap }) => (
-  <DiffLineView
-    prefix={line.prefix}
-    text={line.text}
-    realLineNo={line.realLineNo}
-    filePath={filePath}
-    syntaxHighlight={syntaxHighlight}
-    wrap={wrap}
-  />
-)
-
-/**
- * 大 hunk 虚拟化渲染：只挂载可见窗口的行，滚动时动态补行。
- * 使用外层滚动容器（scrollRef），保证多个 hunk 共用同一滚动条。
- * 固定行高（DIFF_LINE_HEIGHT_PX）保证 estimateSize 精确、滚动无跳动。
- */
-const VirtualHunk: React.FC<{
-  lines: ComputedDiffLine[]
-  filePath: string
-  syntaxHighlight: boolean
-  wrap: boolean
-  scrollRef: React.RefObject<HTMLDivElement | null>
-}> = ({ lines, filePath, syntaxHighlight, wrap, scrollRef }) => {
-  const virtualizer = useVirtualizer({
-    count: lines.length,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => DIFF_LINE_HEIGHT_PX,
-    overscan: VIRTUAL_OVERSCAN,
-    getItemKey: (index) => index
-  })
-  const virtualItems = virtualizer.getVirtualItems()
-  const totalSize = virtualizer.getTotalSize()
-
-  // 视口尚未量出尺寸（jsdom / 首帧 / 容器未布局）时，渲染一个尾部窗口，
-  // 避免 0 行空白。真实视口量出后由 virtualizer 接管。
-  const scrolled = virtualItems.length > 0
-  const fallbackCount = Math.min(lines.length, VIRTUAL_OVERSCAN * 2 + 10)
-  const fallbackStart = Math.max(0, lines.length - fallbackCount)
-  const rendered = scrolled
-    ? virtualItems
-    : Array.from({ length: fallbackCount }, (_, i) => fallbackStart + i)
-
-  return (
-    <div className="diff-hunk__virtual" style={{ position: 'relative', height: totalSize }}>
-      {rendered.map((vi) => {
-        const index = typeof vi === 'number' ? vi : vi.index
-        const start = typeof vi === 'number' ? index * DIFF_LINE_HEIGHT_PX : vi.start
-        const size = typeof vi === 'number' ? DIFF_LINE_HEIGHT_PX : vi.size
-        const line = lines[index]
-        return (
-          <div
-            key={index}
-            data-virtual-index={index}
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: '100%',
-              transform: `translateY(${start}px)`,
-              height: size
-            }}
-          >
-            <DiffLineViewInner
-              line={line}
-              filePath={filePath}
-              syntaxHighlight={syntaxHighlight}
-              wrap={wrap}
-            />
-          </div>
-        )
-      })}
-    </div>
-  )
-}
-
-/** Hunk 渲染。小 hunk 全量渲染；大 hunk 虚拟化（只渲染可见窗口） */
 export const HunkView: React.FC<HunkViewProps> = ({
   hunk,
   filePath,
@@ -184,56 +67,70 @@ export const HunkView: React.FC<HunkViewProps> = ({
   wrap = false,
   scrollRef
 }) => {
-  const allLines = useMemo(() => computeDiffLines(hunk), [hunk])
-  // wrap 折行时行高不固定，虚拟化会错位 → 禁用；仅大 hunk + 非折行走虚拟化
-  const useVirtual = allLines.length > VIRTUALIZE_HUNK_LINE_THRESHOLD && !wrap && !!scrollRef
-
-  // 虚拟化路径本身是性能护栏（DOM 常数级），无需截断，直接完整渲染；
-  // 仅非虚拟化（小 hunk / 折行）保留截断保护。
   const [showFull, setShowFull] = useState(false)
-  const needsTruncation = !useVirtual && allLines.length > PREVIEW_HUNK_LINE_LIMIT
-  const displayLines = useVirtual || showFull
-    ? allLines
-    : allLines.slice(0, PREVIEW_HUNK_LINE_LIMIT)
+  const [virtualizer, setVirtualizer] = useState<Virtualizer>()
+
+  useEffect(() => {
+    const scrollElement = scrollRef?.current
+    if (!scrollElement) return
+
+    const lease = acquirePierreVirtualizer(scrollElement)
+    setVirtualizer(lease.virtualizer)
+    return lease.release
+  }, [scrollRef])
+
+  const preview = useMemo(
+    () => buildHunkPatch(
+      filePath,
+      hunk,
+      showFull ? undefined : PREVIEW_HUNK_LINE_LIMIT
+    ),
+    [filePath, hunk, showFull]
+  )
+  const policy = useMemo(
+    () => selectDiffRenderPolicy(preview.patch.length, syntaxHighlight),
+    [preview.patch.length, syntaxHighlight]
+  )
+  const options = useMemo<FileDiffOptions<undefined>>(() => ({
+    diffStyle: 'unified',
+    overflow: wrap ? 'wrap' : 'scroll',
+    disableFileHeader: true,
+    hunkSeparators: 'line-info-basic',
+    lineDiffType: policy.lineDiffType,
+    maxLineDiffLength: policy.maxLineDiffLength,
+    tokenizeMaxLineLength: policy.tokenizeMaxLineLength,
+    unsafeCSS: PIERRE_CSS
+  }), [policy, wrap])
+
+  const diff = (
+    <PatchDiff
+      patch={preview.patch}
+      options={options}
+      metrics={DIFF_METRICS}
+      disableWorkerPool={policy.disableWorkerPool}
+      className="nova-pierre-diff"
+    />
+  )
 
   return (
-    <div className="diff-hunk">
-      <div className="diff-hunk__header">
-        @@ -{hunk.oldStart},{hunk.oldLines} +{hunk.newStart},{hunk.newLines} @@
-      </div>
-      {useVirtual ? (
-        <VirtualHunk
-          lines={displayLines}
-          filePath={filePath}
-          syntaxHighlight={syntaxHighlight}
-          wrap={wrap}
-          scrollRef={scrollRef}
-        />
-      ) : (
-        <div className={`diff-hunk__content${wrap ? ' diff-hunk__content--wrap' : ''}`}>
-          {displayLines.map((line, idx) => (
-            <DiffLineView
-              key={idx}
-              prefix={line.prefix}
-              text={line.text}
-              realLineNo={line.realLineNo}
-              filePath={filePath}
-              syntaxHighlight={syntaxHighlight}
-              wrap={wrap}
-            />
-          ))}
-        </div>
-      )}
-      {needsTruncation && !showFull && (
+    <div className="diff-hunk diff-hunk--pierre">
+      {scrollRef && !virtualizer ? (
+        <div className="diff-hunk__pending">正在准备差异视图…</div>
+      ) : virtualizer ? (
+        <VirtualizerContext.Provider value={virtualizer}>
+          {diff}
+        </VirtualizerContext.Provider>
+      ) : diff}
+      {preview.omittedLines > 0 && (
         <Button
-          label={`还有 ${allLines.length - PREVIEW_HUNK_LINE_LIMIT} 行未显示，点击展开完整 hunk`}
+          label={`还有 ${preview.omittedLines} 行未显示，点击展开完整 hunk`}
           variant="ghost"
           size="sm"
           className="diff-hunk__truncation"
           onClick={() => setShowFull(true)}
         />
       )}
-      {needsTruncation && showFull && (
+      {showFull && preview.totalLines > PREVIEW_HUNK_LINE_LIMIT && (
         <Button
           label="点击折叠"
           variant="ghost"
@@ -248,13 +145,10 @@ export const HunkView: React.FC<HunkViewProps> = ({
   )
 }
 
-/**
- * 按 hunk content 的 +/- 前缀统计真实增删行。
- * hunk.oldLines/newLines 是 hunk 头跨度（含上下文行），不能当增删计数。
- */
 export function countEntryChanges(entry: DiffEntry): { additions: number; deletions: number } {
   let additions = 0
   let deletions = 0
+
   for (const hunk of entry.hunks) {
     if (!hunk.content) continue
     for (const line of hunk.content.split('\n')) {
@@ -262,5 +156,6 @@ export function countEntryChanges(entry: DiffEntry): { additions: number; deleti
       else if (line.startsWith('-')) deletions++
     }
   }
+
   return { additions, deletions }
 }

--- a/src/renderer/features/diff/pierrePatch.ts
+++ b/src/renderer/features/diff/pierrePatch.ts
@@ -1,0 +1,72 @@
+import type { DiffHunk } from '../../../shared/diff/types'
+
+export interface HunkPatchPreview {
+  patch: string
+  totalLines: number
+  renderedLines: number
+  omittedLines: number
+}
+
+function splitHunkContent(content: string): string[] {
+  return content === '' ? [] : content.split('\n')
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, '/').replace(/^\.\//, '')
+}
+
+function formatGitPath(filePath: string): string {
+  return /[\s"\\]/.test(filePath) ? JSON.stringify(filePath) : filePath
+}
+
+function inferStatus(hunk: DiffHunk): 'added' | 'modified' | 'deleted' {
+  if (hunk.oldStart === 0 && hunk.oldLines === 0) return 'added'
+  if (hunk.newStart === 0 && hunk.newLines === 0) return 'deleted'
+  return 'modified'
+}
+
+function countSpan(lines: string[]): { oldLines: number; newLines: number } {
+  let oldLines = 0
+  let newLines = 0
+
+  for (const line of lines) {
+    if (!line.startsWith('+')) oldLines++
+    if (!line.startsWith('-')) newLines++
+  }
+
+  return { oldLines, newLines }
+}
+
+export function buildHunkPatch(
+  filePath: string,
+  hunk: DiffHunk,
+  lineLimit?: number
+): HunkPatchPreview {
+  const normalizedPath = normalizePath(filePath)
+  const status = inferStatus(hunk)
+  const allLines = splitHunkContent(hunk.content)
+  const rendered = lineLimit === undefined ? allLines : allLines.slice(0, lineLimit)
+  const { oldLines, newLines } = countSpan(rendered)
+
+  const oldPath = status === 'added' ? '/dev/null' : `a/${normalizedPath}`
+  const newPath = status === 'deleted' ? '/dev/null' : `b/${normalizedPath}`
+  const patchLines = [
+    `diff --git ${formatGitPath(`a/${normalizedPath}`)} ${formatGitPath(`b/${normalizedPath}`)}`,
+    `--- ${formatGitPath(oldPath)}`,
+    `+++ ${formatGitPath(newPath)}`
+  ]
+
+  if (rendered.length > 0) {
+    patchLines.push(
+      `@@ -${hunk.oldStart},${oldLines} +${hunk.newStart},${newLines} @@`,
+      ...rendered
+    )
+  }
+
+  return {
+    patch: patchLines.join('\n'),
+    totalLines: allLines.length,
+    renderedLines: rendered.length,
+    omittedLines: allLines.length - rendered.length
+  }
+}

--- a/src/renderer/features/diff/pierreVirtualizer.ts
+++ b/src/renderer/features/diff/pierreVirtualizer.ts
@@ -1,0 +1,42 @@
+import { Virtualizer } from '@pierre/diffs'
+
+interface VirtualizerEntry {
+  virtualizer: Virtualizer
+  references: number
+}
+
+const virtualizers = new WeakMap<HTMLElement, VirtualizerEntry>()
+
+export function acquirePierreVirtualizer(scrollElement: HTMLElement): {
+  virtualizer: Virtualizer
+  release: () => void
+} {
+  let entry = virtualizers.get(scrollElement)
+
+  if (!entry) {
+    const virtualizer = new Virtualizer()
+    virtualizer.setup(scrollElement)
+    entry = { virtualizer, references: 0 }
+    virtualizers.set(scrollElement, entry)
+  }
+
+  entry.references++
+  let released = false
+
+  return {
+    virtualizer: entry.virtualizer,
+    release: () => {
+      if (released) return
+      released = true
+
+      const current = virtualizers.get(scrollElement)
+      if (!current) return
+
+      current.references--
+      if (current.references > 0) return
+
+      current.virtualizer.cleanUp()
+      virtualizers.delete(scrollElement)
+    }
+  }
+}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { WorkerPoolContextProvider } from '@pierre/diffs/react'
+import DiffWorkerUrl from '@pierre/diffs/worker/worker.js?worker&url'
 import App from './App'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { installRendererStallDetector } from '../shared/diagnostics/stallDetector'
@@ -15,7 +17,19 @@ installRendererStallDetector()
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ErrorBoundary>
-      <App />
+      <WorkerPoolContextProvider
+        poolOptions={{
+          poolSize: 2,
+          workerFactory: () => new Worker(DiffWorkerUrl, { type: 'module' })
+        }}
+        highlighterOptions={{
+          theme: { light: 'pierre-light', dark: 'pierre-dark' },
+          lineDiffType: 'word-alt',
+          preferredHighlighter: 'shiki-wasm'
+        }}
+      >
+        <App />
+      </WorkerPoolContextProvider>
     </ErrorBoundary>
   </React.StrictMode>
 )

--- a/tests/renderer/features/diff/diffLines.test.ts
+++ b/tests/renderer/features/diff/diffLines.test.ts
@@ -1,25 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { computeDiffLines, countEntryChanges } from '../../../../src/renderer/features/diff/diffLines'
-import type { DiffEntry, DiffHunk } from '../../../../src/shared/diff/types'
-
-describe('computeDiffLines', () => {
-  it('上下文 / 新增 / 删除行号按 oldStart·newStart 递进', () => {
-    const hunk: DiffHunk = {
-      oldStart: 10,
-      oldLines: 3,
-      newStart: 20,
-      newLines: 4,
-      content: ' ctx\n-old\n+new1\n+new2'
-    }
-    const lines = computeDiffLines(hunk)
-    expect(lines).toEqual([
-      { prefix: ' ', text: 'ctx', realLineNo: 10 },
-      { prefix: '-', text: 'old', realLineNo: 11 },
-      { prefix: '+', text: 'new1', realLineNo: 21 },
-      { prefix: '+', text: 'new2', realLineNo: 22 }
-    ])
-  })
-})
+import {
+  LARGE_PATCH_CHAR_THRESHOLD,
+  MAX_TOKENIZED_LINE_LENGTH,
+  countEntryChanges,
+  selectDiffRenderPolicy
+} from '../../../../src/renderer/features/diff/diffLines'
+import type { DiffEntry } from '../../../../src/shared/diff/types'
 
 describe('countEntryChanges', () => {
   it('只统计 +/- 前缀行，不含上下文', () => {
@@ -36,6 +22,7 @@ describe('countEntryChanges', () => {
         }
       ]
     }
+
     expect(countEntryChanges(entry)).toEqual({ additions: 3, deletions: 2 })
   })
 
@@ -45,6 +32,36 @@ describe('countEntryChanges', () => {
       status: 'added',
       hunks: [{ oldStart: 0, oldLines: 0, newStart: 1, newLines: 0, content: '' }]
     }
+
     expect(countEntryChanges(entry)).toEqual({ additions: 0, deletions: 0 })
+  })
+})
+
+describe('selectDiffRenderPolicy', () => {
+  it('普通语法模式使用 Worker 和行内差异', () => {
+    expect(selectDiffRenderPolicy(1024, true)).toEqual({
+      disableWorkerPool: false,
+      lineDiffType: 'word-alt',
+      maxLineDiffLength: MAX_TOKENIZED_LINE_LENGTH,
+      tokenizeMaxLineLength: MAX_TOKENIZED_LINE_LENGTH
+    })
+  })
+
+  it('文本模式关闭 Worker、高亮和行内差异', () => {
+    expect(selectDiffRenderPolicy(1024, false)).toEqual({
+      disableWorkerPool: true,
+      lineDiffType: 'none',
+      maxLineDiffLength: 0,
+      tokenizeMaxLineLength: 0
+    })
+  })
+
+  it('超大 patch 自动降级为纯文本策略', () => {
+    expect(selectDiffRenderPolicy(LARGE_PATCH_CHAR_THRESHOLD + 1, true)).toEqual({
+      disableWorkerPool: true,
+      lineDiffType: 'none',
+      maxLineDiffLength: 0,
+      tokenizeMaxLineLength: 0
+    })
   })
 })

--- a/tests/renderer/features/inspector/ReviewTab.test.tsx
+++ b/tests/renderer/features/inspector/ReviewTab.test.tsx
@@ -2,6 +2,30 @@
 
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@pierre/diffs', () => ({
+  DEFAULT_VIRTUAL_FILE_METRICS: {
+    lineHeight: 20,
+    hunkSeparatorHeight: 20,
+    spacing: 0
+  }
+}))
+
+vi.mock('@pierre/diffs/react', async () => {
+  const ReactModule = await import('react')
+  return {
+    VirtualizerContext: ReactModule.createContext(undefined),
+    PatchDiff: () => ReactModule.createElement('div', { 'data-testid': 'pierre-diff' })
+  }
+})
+
+vi.mock('../../../../src/renderer/features/diff/pierreVirtualizer', () => ({
+  acquirePierreVirtualizer: () => ({
+    virtualizer: {},
+    release: () => undefined
+  })
+}))
+
 import { ReviewTab } from '../../../../src/renderer/features/inspector/ReviewTab'
 import { resetLayoutStoreForTests, useLayoutStore } from '../../../../src/renderer/stores/useLayoutStore'
 import { resetChatStoreForTests, useChatStore } from '../../../../src/renderer/stores/useChatStore'

--- a/tests/unit/renderer/diffVirtualization.test.tsx
+++ b/tests/unit/renderer/diffVirtualization.test.tsx
@@ -1,70 +1,145 @@
 // @vitest-environment jsdom
 
 import React, { createRef } from 'react'
-import { describe, expect, it } from 'vitest'
-import { HunkView, VIRTUALIZE_HUNK_LINE_THRESHOLD } from '../../../src/renderer/features/diff/diffLines'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, renderDom } from './renderDom'
 import type { DiffHunk } from '../../../src/shared/diff/types'
 
-function makeHunk(lineCount: number): DiffHunk {
-  const lines: string[] = []
-  for (let i = 0; i < lineCount; i++) {
-    if (i % 3 === 0) lines.push(`+const value${i} = call(${i});`)
-    else if (i % 3 === 1) lines.push(`-const old${i} = legacy(${i});`)
-    else lines.push(` context line ${i}`)
+const mocks = vi.hoisted(() => ({
+  patchDiff: vi.fn(),
+  acquire: vi.fn(),
+  release: vi.fn(),
+  virtualizer: {}
+}))
+
+vi.mock('@pierre/diffs', () => ({
+  DEFAULT_VIRTUAL_FILE_METRICS: {
+    lineHeight: 20,
+    hunkSeparatorHeight: 20,
+    spacing: 0
   }
+}))
+
+vi.mock('@pierre/diffs/react', async () => {
+  const ReactModule = await import('react')
+  return {
+    VirtualizerContext: ReactModule.createContext(undefined),
+    PatchDiff: (props: Record<string, unknown>) => {
+      mocks.patchDiff(props)
+      return ReactModule.createElement('div', {
+        'data-testid': 'pierre-diff',
+        'data-patch': props.patch
+      })
+    }
+  }
+})
+
+vi.mock('../../../src/renderer/features/diff/pierreVirtualizer', () => ({
+  acquirePierreVirtualizer: (element: HTMLElement) => {
+    mocks.acquire(element)
+    return {
+      virtualizer: mocks.virtualizer,
+      release: mocks.release
+    }
+  }
+}))
+
+import {
+  HunkView,
+  PREVIEW_HUNK_LINE_LIMIT
+} from '../../../src/renderer/features/diff/diffLines'
+
+function makeHunk(lineCount: number): DiffHunk {
+  const lines = Array.from({ length: lineCount }, (_, index) => (
+    index % 2 === 0
+      ? `+const value${index} = ${index}`
+      : `-const old${index} = ${index}`
+  ))
+
   return {
     oldStart: 1,
-    oldLines: lineCount,
+    oldLines: Math.floor(lineCount / 2),
     newStart: 1,
-    newLines: lineCount,
+    newLines: Math.ceil(lineCount / 2),
     content: lines.join('\n')
   }
 }
 
-describe('HunkView 虚拟化', () => {
-  it('小 hunk（≤阈值）全量渲染', () => {
-    const hunk = makeHunk(10)
-    const renderer = renderDom(<HunkView hunk={hunk} filePath="a.ts" />)
-    const rows = renderer.container.querySelectorAll('.diff-line')
-    expect(rows.length).toBe(10)
-    renderer.unmount()
+describe('HunkView Pierre 集成', () => {
+  beforeEach(() => {
+    mocks.patchDiff.mockClear()
+    mocks.acquire.mockClear()
+    mocks.release.mockClear()
   })
 
-  it('大 hunk（>阈值）走虚拟化：挂载行数有界，不随总行数线性增长', () => {
+  it('复用 ReviewTab 外层滚动容器的 Pierre Virtualizer', () => {
     const scrollRef = createRef<HTMLDivElement>()
-    const big = makeHunk(1000)
-    const lineCount = big.content.split('\n').length
     const renderer = renderDom(
-      <div ref={scrollRef} style={{ height: 400, overflow: 'auto' }}>
-        <HunkView hunk={big} filePath="a.ts" scrollRef={scrollRef} />
+      <div ref={scrollRef}>
+        <HunkView
+          hunk={makeHunk(20)}
+          filePath="src/a.ts"
+          scrollRef={scrollRef}
+        />
       </div>
     )
-    const rows = renderer.container.querySelectorAll('.diff-line')
-    // 虚拟化：只渲染可见窗口 + overscan，远小于总行数
-    expect(rows.length).toBeLessThan(200)
-    expect(rows.length).toBeGreaterThan(0)
-    // 虚拟容器高度 = 全部行高（虚拟化路径不再截断，撑起完整滚动条）
-    const virtual = renderer.container.querySelector<HTMLElement>('.diff-hunk__virtual')
-    expect(virtual?.style.height).toBe(`${lineCount * 22}px`)
+
+    expect(mocks.acquire).toHaveBeenCalledTimes(1)
+    expect(mocks.acquire).toHaveBeenCalledWith(scrollRef.current)
+    expect(mocks.patchDiff).toHaveBeenCalledTimes(1)
+    expect(mocks.patchDiff.mock.calls[0][0]).toMatchObject({
+      disableWorkerPool: false
+    })
+
     renderer.unmount()
+    expect(mocks.release).toHaveBeenCalledTimes(1)
   })
 
-  it('wrap 模式禁用虚拟化（行高不固定会错位）', () => {
+  it('展开大 hunk 后仍走同一 Virtualizer，并向 Pierre 交付完整 patch', () => {
     const scrollRef = createRef<HTMLDivElement>()
-    const big = makeHunk(200)
+    const hunk = makeHunk(PREVIEW_HUNK_LINE_LIMIT + 20)
     const renderer = renderDom(
-      <div ref={scrollRef} style={{ height: 400, overflow: 'auto' }}>
-        <HunkView hunk={big} filePath="a.ts" scrollRef={scrollRef} wrap />
+      <div ref={scrollRef}>
+        <HunkView
+          hunk={hunk}
+          filePath="src/large.ts"
+          scrollRef={scrollRef}
+        />
       </div>
     )
-    const rows = renderer.container.querySelectorAll('.diff-line')
-    expect(rows.length).toBe(200)
-    expect(renderer.container.querySelector('.diff-hunk__virtual')).toBeNull()
+
+    const initial = mocks.patchDiff.mock.calls.at(-1)?.[0] as { patch: string }
+    expect(initial.patch).not.toContain(`value${PREVIEW_HUNK_LINE_LIMIT + 18}`)
+
+    const expand = renderer.container.querySelector<HTMLButtonElement>('.diff-hunk__truncation')
+    expect(expand).not.toBeNull()
+    act(() => expand?.click())
+
+    const expanded = mocks.patchDiff.mock.calls.at(-1)?.[0] as { patch: string }
+    expect(expanded.patch).toContain(`value${PREVIEW_HUNK_LINE_LIMIT + 18}`)
+    expect(mocks.acquire).toHaveBeenCalledTimes(1)
+
     renderer.unmount()
   })
 
-  it('阈值常量已导出且合理', () => {
-    expect(VIRTUALIZE_HUNK_LINE_THRESHOLD).toBeGreaterThan(0)
+  it('文本模式显式关闭 Worker 和昂贵高亮', () => {
+    const renderer = renderDom(
+      <HunkView
+        hunk={makeHunk(4)}
+        filePath="notes.txt"
+        syntaxHighlight={false}
+      />
+    )
+
+    expect(mocks.patchDiff.mock.calls.at(-1)?.[0]).toMatchObject({
+      disableWorkerPool: true,
+      options: {
+        lineDiffType: 'none',
+        maxLineDiffLength: 0,
+        tokenizeMaxLineLength: 0
+      }
+    })
+
+    renderer.unmount()
   })
 })

--- a/tests/unit/renderer/pierrePatch.test.ts
+++ b/tests/unit/renderer/pierrePatch.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import type { DiffHunk } from '../../../src/shared/diff/types'
+import { buildHunkPatch } from '../../../src/renderer/features/diff/pierrePatch'
+
+describe('buildHunkPatch', () => {
+  it('生成 Pierre 可消费的 unified patch，并规范 Windows 路径', () => {
+    const hunk: DiffHunk = {
+      oldStart: 10,
+      oldLines: 2,
+      newStart: 10,
+      newLines: 2,
+      content: ' keep\n-old\n+new'
+    }
+
+    const result = buildHunkPatch('src\\value.ts', hunk)
+
+    expect(result.patch).toContain('diff --git a/src/value.ts b/src/value.ts')
+    expect(result.patch).toContain('--- a/src/value.ts')
+    expect(result.patch).toContain('+++ b/src/value.ts')
+    expect(result.patch).toContain('@@ -10,2 +10,2 @@')
+    expect(result.omittedLines).toBe(0)
+  })
+
+  it('截断时按实际展示行重新计算 hunk 跨度', () => {
+    const hunk: DiffHunk = {
+      oldStart: 3,
+      oldLines: 4,
+      newStart: 3,
+      newLines: 4,
+      content: ' context\n-remove\n+add\n tail'
+    }
+
+    const result = buildHunkPatch('a.ts', hunk, 3)
+
+    expect(result.patch).toContain('@@ -3,2 +3,2 @@')
+    expect(result.patch).not.toContain(' tail')
+    expect(result).toMatchObject({
+      totalLines: 4,
+      renderedLines: 3,
+      omittedLines: 1
+    })
+  })
+
+  it('新增和删除文件使用 /dev/null 边界', () => {
+    const added = buildHunkPatch('new file.ts', {
+      oldStart: 0,
+      oldLines: 0,
+      newStart: 1,
+      newLines: 1,
+      content: '+hello'
+    })
+    const deleted = buildHunkPatch('old.ts', {
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 0,
+      newLines: 0,
+      content: '-bye'
+    })
+
+    expect(added.patch).toContain('--- /dev/null')
+    expect(added.patch).toContain('+++ "b/new file.ts"')
+    expect(deleted.patch).toContain('--- a/old.ts')
+    expect(deleted.patch).toContain('+++ /dev/null')
+  })
+
+  it('空 content 不伪造 1/1 hunk', () => {
+    const result = buildHunkPatch('empty.ts', {
+      oldStart: 1,
+      oldLines: 0,
+      newStart: 1,
+      newLines: 0,
+      content: ''
+    })
+
+    expect(result.patch).not.toContain('@@')
+    expect(result).toMatchObject({
+      totalLines: 0,
+      renderedLines: 0,
+      omittedLines: 0
+    })
+  })
+})


### PR DESCRIPTION
## 改动

- 文件差异审查改用 Pierre 渲染，获得更完整的语言高亮与行内差异展示
- 高亮任务通过两个 Worker 执行，避免占用 Renderer 主线程
- 保留 Nova 现有的 diff 契约、Inspector、审查状态、接受与回退流程
- 新增独立 patch 适配层，第三方类型不会进入 shared、runtime 或 checkpoint 边界
- 文本模式和超大 patch 自动关闭昂贵的高亮与行内差异处理
- 保留 500 行预览保护，并补充 patch 转换边界测试

## 架构边界

- Nova 的 `DiffEntry` 仍是跨层唯一契约
- Pierre 只负责 Renderer 展示，不拥有审查状态或文件恢复行为
- StreamingFileCard 继续使用原有轻量高亮，本次不扩大修改范围

## 验证

- 已确认分支基于 `dev` 当前提交 `6c61276870249009cc004b566b4737eccfc1189c`
- 已静态核对 Pierre React、Worker Pool、PatchDiff 与 Electron Vite 的公开接口
- 已新增 unified patch 转换测试

## 待本地确认

当前执行环境无法访问 npm registry，因此未能生成 `package-lock.json` 或执行依赖安装后的 typecheck、test、build。合并前需要在本地运行：

```bash
npm install
npm run typecheck
npm test
npm run build
```

该 PR 保持 Draft，等待完整本地验证与界面审查。