### PR TITLE
feat(chat): 增加 Nova 工作中状态反馈

### DIFF
--- a/src/renderer/features/chat/AssistantPendingIndicator.css
+++ b/src/renderer/features/chat/AssistantPendingIndicator.css
@@ -50,7 +50,7 @@
   transition: transform 820ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-/* 旧的“正在思考”文案保留给读屏器；视觉上只显示 Nova 的随机工作文案。 */
+/* 稳定文案仅供读屏器，视觉层展示随机工作文案。 */
 .assistant-pending.nova-working-indicator .assistant-pending__label {
   position: absolute;
   width: 1px;

--- a/src/renderer/features/chat/AssistantPendingIndicator.css
+++ b/src/renderer/features/chat/AssistantPendingIndicator.css
@@ -7,6 +7,10 @@
   color: var(--text-secondary);
 }
 
+.chat-msg--assistant .nova-working-indicator:not(:first-child) {
+  margin-top: 12px;
+}
+
 .nova-working-orb {
   position: relative;
   display: inline-block;

--- a/src/renderer/features/chat/AssistantPendingIndicator.css
+++ b/src/renderer/features/chat/AssistantPendingIndicator.css
@@ -1,0 +1,108 @@
+.assistant-pending.nova-working-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 30px;
+  max-width: 100%;
+  color: var(--text-secondary);
+}
+
+.nova-working-orb {
+  position: relative;
+  display: inline-block;
+  flex: 0 0 auto;
+  isolation: isolate;
+}
+
+.nova-working-orb__halo {
+  position: absolute;
+  inset: 16%;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(167, 139, 250, 0.3) 0%,
+    rgba(139, 92, 246, 0.14) 46%,
+    rgba(124, 58, 237, 0) 74%
+  );
+  filter: blur(3px);
+  opacity: 0.72;
+  animation: nova-working-orb-breathe 2.6s ease-in-out infinite;
+}
+
+.nova-working-orb__dot {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 2px;
+  height: 2px;
+  margin: -1px 0 0 -1px;
+  border-radius: 50%;
+  background: #c4b5fd;
+  box-shadow:
+    0 0 3px rgba(196, 181, 253, 0.82),
+    0 0 7px rgba(139, 92, 246, 0.42);
+  opacity: 0.96;
+  will-change: transform;
+  transition: transform 820ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* 旧的“正在思考”文案保留给读屏器；视觉上只显示 Nova 的随机工作文案。 */
+.assistant-pending.nova-working-indicator .assistant-pending__label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.nova-working-indicator__copy {
+  min-width: 0;
+  max-width: min(440px, calc(100vw - 180px));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.005em;
+  text-shadow: 0 0 14px rgba(139, 92, 246, 0.12);
+  animation: nova-working-copy-in 320ms ease-out both;
+}
+
+@keyframes nova-working-orb-breathe {
+  0%, 100% {
+    transform: scale(0.88);
+    opacity: 0.46;
+  }
+  50% {
+    transform: scale(1.12);
+    opacity: 0.84;
+  }
+}
+
+@keyframes nova-working-copy-in {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nova-working-orb__halo,
+  .nova-working-indicator__copy {
+    animation: none;
+  }
+
+  .nova-working-orb__dot {
+    transition: none;
+  }
+}

--- a/src/renderer/features/chat/AssistantPendingIndicator.tsx
+++ b/src/renderer/features/chat/AssistantPendingIndicator.tsx
@@ -44,7 +44,7 @@ function prefersReducedMotion(): boolean {
     && window.matchMedia('(prefers-reduced-motion: reduce)').matches
 }
 
-/** 模型接管但尚未产出可见消息块时，给用户明确的 Nova 工作中反馈。 */
+/** 当前 assistant 轮次仍在运行时，给用户明确的 Nova 工作中反馈。 */
 export const AssistantPendingIndicator: React.FC = () => {
   const [workingMessage, setWorkingMessage] = useState(() =>
     pickNonRepeatingWorkingMessage(lastWorkingMessage)

--- a/src/renderer/features/chat/AssistantPendingIndicator.tsx
+++ b/src/renderer/features/chat/AssistantPendingIndicator.tsx
@@ -1,21 +1,85 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { NovaWorkingOrb } from './NovaWorkingOrb'
+import './AssistantPendingIndicator.css'
 
-/** 模型接管但尚未产出消息块时的轻量等待态。 */
+export const NOVA_WORKING_MESSAGES = [
+  'Nova正在捣鼓中...',
+  '老板来了，Nova敲代码的速度更快了...',
+  '正在加班中...',
+  'Nova正在翻代码，马上回来...',
+  '正在和Bug讲道理...',
+  'Nova正在把思路焊起来...',
+  '正在摸清这个仓库的脾气...',
+  '代码在路上，Nova正在收尾...',
+  '认真干活中，摸鱼进程已暂停...',
+  'Nova正在让这段代码听话一点...'
+] as const
+
+const MESSAGE_INTERVAL_MS = 4600
+let lastWorkingMessage: string | null = null
+
+export function pickNonRepeatingWorkingMessage(
+  previous: string | null,
+  random: () => number = Math.random
+): string {
+  if (NOVA_WORKING_MESSAGES.length === 1) return NOVA_WORKING_MESSAGES[0]
+
+  const previousIndex = previous === null
+    ? -1
+    : NOVA_WORKING_MESSAGES.indexOf(previous as typeof NOVA_WORKING_MESSAGES[number])
+  const candidateCount = previousIndex >= 0
+    ? NOVA_WORKING_MESSAGES.length - 1
+    : NOVA_WORKING_MESSAGES.length
+  const normalizedRandom = Math.min(0.999999, Math.max(0, random()))
+  let candidateIndex = Math.floor(normalizedRandom * candidateCount)
+
+  if (previousIndex >= 0 && candidateIndex >= previousIndex) {
+    candidateIndex += 1
+  }
+
+  return NOVA_WORKING_MESSAGES[candidateIndex]
+}
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+/** 模型接管但尚未产出可见消息块时，给用户明确的 Nova 工作中反馈。 */
 export const AssistantPendingIndicator: React.FC = () => {
+  const [workingMessage, setWorkingMessage] = useState(() =>
+    pickNonRepeatingWorkingMessage(lastWorkingMessage)
+  )
+
+  useEffect(() => {
+    lastWorkingMessage = workingMessage
+  }, [workingMessage])
+
+  useEffect(() => {
+    if (prefersReducedMotion()) return undefined
+
+    const timer = window.setInterval(() => {
+      setWorkingMessage(previous => pickNonRepeatingWorkingMessage(previous))
+    }, MESSAGE_INTERVAL_MS)
+
+    return () => window.clearInterval(timer)
+  }, [])
+
   return (
     <div
-      className="assistant-pending"
+      className="assistant-pending nova-working-indicator"
       role="status"
       aria-live="polite"
-      aria-label="Nova 正在准备回复"
     >
-      <span className="assistant-pending__dots" aria-hidden="true">
-        <span />
-        <span />
-        <span />
-      </span>
-      <span className="assistant-pending__text">
-        <span className="assistant-pending__label">正在思考</span>
+      <NovaWorkingOrb size={28} />
+      <span className="assistant-pending__label">正在思考</span>
+      <span
+        key={workingMessage}
+        className="nova-working-indicator__copy"
+        aria-hidden="true"
+      >
+        {workingMessage}
       </span>
     </div>
   )

--- a/src/renderer/features/chat/AssistantPendingIndicator.tsx
+++ b/src/renderer/features/chat/AssistantPendingIndicator.tsx
@@ -22,8 +22,6 @@ export function pickNonRepeatingWorkingMessage(
   previous: string | null,
   random: () => number = Math.random
 ): string {
-  if (NOVA_WORKING_MESSAGES.length === 1) return NOVA_WORKING_MESSAGES[0]
-
   const previousIndex = previous === null
     ? -1
     : NOVA_WORKING_MESSAGES.indexOf(previous as typeof NOVA_WORKING_MESSAGES[number])

--- a/src/renderer/features/chat/MessageItem.tsx
+++ b/src/renderer/features/chat/MessageItem.tsx
@@ -282,6 +282,7 @@ function MessageItemInner({
     ? hasVisibleBlocks(msg.blocks, currentMode)
     : !!thinkingContent.trim() || !!textContent.trim() || hasVisibleToolCalls(msg.toolCalls, currentMode)
   const shouldShowPending = isCurrentAssistantGenerating && !hasVisibleContent
+  const shouldShowWorkingTail = isCurrentAssistantGenerating && hasVisibleContent
   const handleRenderPoolTick = isStaticRow ? undefined : onRenderPoolTick
 
   const turnPhase = resolveTurnPhase(msg.id, currentGeneratingMessageId, isGenerating)
@@ -595,6 +596,9 @@ function MessageItemInner({
             {...(onRejectAllFiles && !tier1DiffStale ? { onRejectAll: (filePaths: string[]) => onRejectAllFiles(currentSessionId, msg.id, filePaths) } : {})}
           />
         )}
+
+        {/* 已经出现 thinking/tool/text 后仍保留在轮次尾部，明确告诉用户 Agent 还在继续工作。 */}
+        {shouldShowWorkingTail && <AssistantPendingIndicator />}
     </>
   )
 

--- a/src/renderer/features/chat/MessageItem.tsx
+++ b/src/renderer/features/chat/MessageItem.tsx
@@ -14,7 +14,7 @@ import { Thumbnail } from '@astryxdesign/core/Thumbnail'
 import { ThinkingBlock } from './ThinkingBlock'
 import { StreamingTextBlock } from './StreamingTextBlock'
 import { DiffViewer } from '../diff/DiffViewer'
-import { isActiveThinkingBlock, shouldRenderToolBlock } from './renderingPolicy'
+import { isActiveThinkingBlock } from './renderingPolicy'
 import { MarkdownRenderer } from './MarkdownRenderer'
 import { ToolCallGroup } from './ToolCallGroup'
 import { buildBlockRenderUnits, type RenderUnit } from './toolCallGrouping'
@@ -33,7 +33,7 @@ import {
   useComposeStageStore
 } from '../compose/useComposeStageStore'
 import type { Mode } from '../../../shared/session/types'
-import type { ExtendedMessage, ExtendedToolCall, RendererMessageBlock, MessageDiffCache } from '../../stores/types'
+import type { ExtendedMessage, MessageDiffCache } from '../../stores/types'
 import type { DiffEntry } from '../../../shared/diff/types'
 import type { MessageRenderMode } from './messageRenderTier'
 
@@ -82,24 +82,6 @@ export interface MessageItemProps {
   diffPlaceholders?: Array<{ filePath: string; status: DiffEntry['status'] }>
   /** 按需加载 diff 的回调，MessageItem 挂载时调用 */
   onLoadDiffs?: (sessionId: string, messageId: string) => void
-}
-
-// ── 模块级辅助函数（从 ChatPanel.tsx 搬入） ──────────────────────
-
-function hasVisibleToolCalls(toolCalls: ExtendedToolCall[] | undefined, mode: Mode): boolean {
-  return !!toolCalls?.some(toolCall => shouldRenderToolBlock(mode, toolCall.name))
-}
-
-function hasVisibleBlocks(blocks: RendererMessageBlock[] | undefined, mode: Mode): boolean {
-  return !!blocks?.some(block => {
-    if (block.type === 'thinking' || block.type === 'text') {
-      return block.content.trim().length > 0
-    }
-    if (block.type === 'image') {
-      return true
-    }
-    return shouldRenderToolBlock(mode, block.toolName)
-  })
 }
 
 type ThinkingParseSource = Pick<ExtendedMessage, 'id'> & {
@@ -218,8 +200,6 @@ function renderMessageUnit(
   return null
 }
 
-// ── 组件主体 ─────────────────────────────────────────────────
-
 function MessageItemInner({
   msg: msgProp,
   renderMode = 'live',
@@ -281,11 +261,6 @@ function MessageItemInner({
   // 高亮（每行炸出大量 token span），在权限弹窗瞬间造成同步重排卡死。
   const isTurnActiveForThisMsg =
     isAssistant && isGenerating && msg.id === currentGeneratingMessageId && !isStaticRow
-  const hasVisibleContent = hasBlocks
-    ? hasVisibleBlocks(msg.blocks, currentMode)
-    : !!thinkingContent.trim() || !!textContent.trim() || hasVisibleToolCalls(msg.toolCalls, currentMode)
-  const shouldShowPending = isCurrentAssistantGenerating && !hasVisibleContent
-  const shouldShowWorkingTail = isCurrentAssistantGenerating && hasVisibleContent
   const handleRenderPoolTick = isStaticRow ? undefined : onRenderPoolTick
 
   const turnPhase = resolveTurnPhase(msg.id, currentGeneratingMessageId, isGenerating)
@@ -421,8 +396,6 @@ function MessageItemInner({
 
   const messageBody = (
     <>
-        {shouldShowPending && <AssistantPendingIndicator />}
-
         {hasBlocks && isAssistant && turnModel ? (
           /* assistant blocks：过程树 → 结论（含 ask 卡片） */
           <>
@@ -605,7 +578,9 @@ function MessageItemInner({
           />
         )}
 
-        {shouldShowWorkingTail && <AssistantPendingIndicator />}
+        {isCurrentAssistantGenerating && (
+          <AssistantPendingIndicator key="assistant-working-status" />
+        )}
     </>
   )
 

--- a/src/renderer/features/chat/NovaWorkingOrb.tsx
+++ b/src/renderer/features/chat/NovaWorkingOrb.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useState } from 'react'
+
+type Point = {
+  x: number
+  y: number
+}
+
+type OrbShape = {
+  name: 'N' | 'O' | 'V' | 'A'
+  points: Point[]
+}
+
+export const NOVA_WORKING_ORB_DOT_COUNT = 24
+
+const SHAPE_INTERVAL_MS = 1500
+const SHAPE_SCALE = 0.54
+
+function resamplePolyline(points: Point[], count: number, closed = false): Point[] {
+  const path = closed ? [...points, points[0]] : points
+  const segments: Array<{ from: Point; to: Point; length: number }> = []
+  let totalLength = 0
+
+  for (let i = 0; i < path.length - 1; i += 1) {
+    const from = path[i]
+    const to = path[i + 1]
+    const length = Math.hypot(to.x - from.x, to.y - from.y)
+    segments.push({ from, to, length })
+    totalLength += length
+  }
+
+  const divisor = closed ? count : Math.max(1, count - 1)
+
+  return Array.from({ length: count }, (_, index) => {
+    const target = (index / divisor) * totalLength
+    let traversed = 0
+
+    for (let segmentIndex = 0; segmentIndex < segments.length; segmentIndex += 1) {
+      const segment = segments[segmentIndex]
+      const isLast = segmentIndex === segments.length - 1
+
+      if (target <= traversed + segment.length || isLast) {
+        const local = segment.length === 0
+          ? 0
+          : Math.min(1, Math.max(0, (target - traversed) / segment.length))
+
+        return {
+          x: segment.from.x + (segment.to.x - segment.from.x) * local,
+          y: segment.from.y + (segment.to.y - segment.from.y) * local
+        }
+      }
+
+      traversed += segment.length
+    }
+
+    return points[points.length - 1]
+  })
+}
+
+function sampleEllipse(count: number): Point[] {
+  return Array.from({ length: count }, (_, index) => {
+    const angle = -Math.PI / 2 + (index / count) * Math.PI * 2
+    return {
+      x: Math.cos(angle) * 0.56,
+      y: Math.sin(angle) * 0.68
+    }
+  })
+}
+
+const SHAPES: OrbShape[] = [
+  {
+    name: 'N',
+    points: resamplePolyline([
+      { x: -0.52, y: -0.68 },
+      { x: -0.52, y: 0.68 },
+      { x: 0.52, y: -0.68 },
+      { x: 0.52, y: 0.68 }
+    ], NOVA_WORKING_ORB_DOT_COUNT)
+  },
+  {
+    name: 'O',
+    points: sampleEllipse(NOVA_WORKING_ORB_DOT_COUNT)
+  },
+  {
+    name: 'V',
+    points: resamplePolyline([
+      { x: -0.6, y: -0.64 },
+      { x: 0, y: 0.72 },
+      { x: 0.6, y: -0.64 }
+    ], NOVA_WORKING_ORB_DOT_COUNT)
+  },
+  {
+    // A 故意保留为三角轮廓：小尺寸下比带横杠的标准 A 更干净，也更像 Nova 自己的符号。
+    name: 'A',
+    points: resamplePolyline([
+      { x: -0.58, y: 0.62 },
+      { x: 0, y: -0.72 },
+      { x: 0.58, y: 0.62 }
+    ], NOVA_WORKING_ORB_DOT_COUNT, true)
+  }
+]
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+export interface NovaWorkingOrbProps {
+  size?: number
+}
+
+/**
+ * Nova 的工作中品牌动效。
+ *
+ * 24 个点只在形状切换时更新一次位置，实际过渡交给 CSS transform，
+ * 避免为等待态常驻 requestAnimationFrame / React 高频重渲染。
+ */
+export const NovaWorkingOrb = React.memo(function NovaWorkingOrb({
+  size = 28
+}: NovaWorkingOrbProps) {
+  const [shapeIndex, setShapeIndex] = useState(0)
+
+  useEffect(() => {
+    if (prefersReducedMotion()) return undefined
+
+    const timer = window.setInterval(() => {
+      setShapeIndex(current => (current + 1) % SHAPES.length)
+    }, SHAPE_INTERVAL_MS)
+
+    return () => window.clearInterval(timer)
+  }, [])
+
+  const shape = SHAPES[shapeIndex]
+  const pixelScale = size * SHAPE_SCALE
+
+  return (
+    <span
+      className="nova-working-orb"
+      style={{ width: size, height: size }}
+      data-shape={shape.name}
+      aria-hidden="true"
+    >
+      <span className="nova-working-orb__halo" />
+      {shape.points.map((point, index) => (
+        <span
+          key={index}
+          className="nova-working-orb__dot"
+          style={{
+            transform: `translate3d(${(point.x * pixelScale).toFixed(2)}px, ${(point.y * pixelScale).toFixed(2)}px, 0)`,
+            transitionDelay: `${index * 6}ms`
+          }}
+        />
+      ))}
+    </span>
+  )
+})

--- a/src/renderer/features/chat/NovaWorkingOrb.tsx
+++ b/src/renderer/features/chat/NovaWorkingOrb.tsx
@@ -10,6 +10,11 @@ type OrbShape = {
   points: Point[]
 }
 
+type OrbFrame = {
+  shapeIndex: number
+  points: Point[]
+}
+
 export const NOVA_WORKING_ORB_DOT_COUNT = 24
 
 const SHAPE_INTERVAL_MS = 1500
@@ -99,6 +104,76 @@ const SHAPES: OrbShape[] = [
   }
 ]
 
+/**
+ * 给每个现有点分配一个唯一目标点，并让所有点的总移动距离尽量短。
+ * N/O/V/A 的拓扑不同，直接按数组下标硬插值会在中间挤成一团；
+ * 这里用最小代价匹配保住点阵在整个变形过程里的均匀感。
+ */
+function assignNearestTargets(source: Point[], target: Point[]): Point[] {
+  const size = source.length
+  const rowPotential = new Array(size + 1).fill(0)
+  const columnPotential = new Array(size + 1).fill(0)
+  const rowForColumn = new Array(size + 1).fill(0)
+  const previousColumn = new Array(size + 1).fill(0)
+
+  for (let row = 1; row <= size; row += 1) {
+    rowForColumn[0] = row
+    let column0 = 0
+    const minCost = new Array(size + 1).fill(Number.POSITIVE_INFINITY)
+    const used = new Array(size + 1).fill(false)
+
+    do {
+      used[column0] = true
+      const row0 = rowForColumn[column0]
+      let delta = Number.POSITIVE_INFINITY
+      let column1 = 0
+
+      for (let column = 1; column <= size; column += 1) {
+        if (used[column]) continue
+
+        const from = source[row0 - 1]
+        const to = target[column - 1]
+        const dx = from.x - to.x
+        const dy = from.y - to.y
+        const cost = dx * dx + dy * dy - rowPotential[row0] - columnPotential[column]
+
+        if (cost < minCost[column]) {
+          minCost[column] = cost
+          previousColumn[column] = column0
+        }
+        if (minCost[column] < delta) {
+          delta = minCost[column]
+          column1 = column
+        }
+      }
+
+      for (let column = 0; column <= size; column += 1) {
+        if (used[column]) {
+          rowPotential[rowForColumn[column]] += delta
+          columnPotential[column] -= delta
+        } else {
+          minCost[column] -= delta
+        }
+      }
+
+      column0 = column1
+    } while (rowForColumn[column0] !== 0)
+
+    do {
+      const column1 = previousColumn[column0]
+      rowForColumn[column0] = rowForColumn[column1]
+      column0 = column1
+    } while (column0 !== 0)
+  }
+
+  const assigned = new Array<Point>(size)
+  for (let column = 1; column <= size; column += 1) {
+    assigned[rowForColumn[column] - 1] = target[column - 1]
+  }
+
+  return assigned
+}
+
 function prefersReducedMotion(): boolean {
   return typeof window !== 'undefined'
     && typeof window.matchMedia === 'function'
@@ -113,41 +188,50 @@ export interface NovaWorkingOrbProps {
  * Nova 的工作中品牌动效。
  *
  * 24 个点只在形状切换时更新一次位置，实际过渡交给 CSS transform，
- * 避免为等待态常驻 requestAnimationFrame / React 高频重渲染。
+ * 没有常驻 requestAnimationFrame，也不会触发高频 React 重渲染。
  */
 export const NovaWorkingOrb = React.memo(function NovaWorkingOrb({
   size = 28
 }: NovaWorkingOrbProps) {
-  const [shapeIndex, setShapeIndex] = useState(0)
+  const [frame, setFrame] = useState<OrbFrame>(() => ({
+    shapeIndex: 0,
+    points: SHAPES[0].points
+  }))
 
   useEffect(() => {
     if (prefersReducedMotion()) return undefined
 
     const timer = window.setInterval(() => {
-      setShapeIndex(current => (current + 1) % SHAPES.length)
+      setFrame(current => {
+        const nextShapeIndex = (current.shapeIndex + 1) % SHAPES.length
+        const nextShape = SHAPES[nextShapeIndex]
+
+        return {
+          shapeIndex: nextShapeIndex,
+          points: assignNearestTargets(current.points, nextShape.points)
+        }
+      })
     }, SHAPE_INTERVAL_MS)
 
     return () => window.clearInterval(timer)
   }, [])
 
-  const shape = SHAPES[shapeIndex]
   const pixelScale = size * SHAPE_SCALE
 
   return (
     <span
       className="nova-working-orb"
       style={{ width: size, height: size }}
-      data-shape={shape.name}
+      data-shape={SHAPES[frame.shapeIndex].name}
       aria-hidden="true"
     >
       <span className="nova-working-orb__halo" />
-      {shape.points.map((point, index) => (
+      {frame.points.map((point, index) => (
         <span
           key={index}
           className="nova-working-orb__dot"
           style={{
-            transform: `translate3d(${(point.x * pixelScale).toFixed(2)}px, ${(point.y * pixelScale).toFixed(2)}px, 0)`,
-            transitionDelay: `${index * 6}ms`
+            transform: `translate3d(${(point.x * pixelScale).toFixed(2)}px, ${(point.y * pixelScale).toFixed(2)}px, 0)`
           }}
         />
       ))}

--- a/tests/unit/renderer/assistantPendingIndicator.test.ts
+++ b/tests/unit/renderer/assistantPendingIndicator.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import {
+  AssistantPendingIndicator,
+  NOVA_WORKING_MESSAGES,
+  pickNonRepeatingWorkingMessage
+} from '../../../src/renderer/features/chat/AssistantPendingIndicator'
+import { NOVA_WORKING_ORB_DOT_COUNT } from '../../../src/renderer/features/chat/NovaWorkingOrb'
+import { renderDom } from './renderDom'
+
+describe('AssistantPendingIndicator', () => {
+  it('工作文案保持 10 条，并保证下一条不会和上一条重复', () => {
+    expect(NOVA_WORKING_MESSAGES).toHaveLength(10)
+
+    for (const previous of NOVA_WORKING_MESSAGES) {
+      expect(pickNonRepeatingWorkingMessage(previous, () => 0)).not.toBe(previous)
+      expect(pickNonRepeatingWorkingMessage(previous, () => 0.999999)).not.toBe(previous)
+    }
+  })
+
+  it('渲染 Nova N/O/V/A 点阵工作态和随机文案', () => {
+    const renderer = renderDom(React.createElement(AssistantPendingIndicator))
+    const pending = renderer.container.querySelector('.assistant-pending')
+    const orb = renderer.container.querySelector('.nova-working-orb')
+    const copy = renderer.container.querySelector('.nova-working-indicator__copy')
+
+    expect(pending).not.toBeNull()
+    expect(orb?.getAttribute('data-shape')).toBe('N')
+    expect(orb?.querySelectorAll('.nova-working-orb__dot')).toHaveLength(NOVA_WORKING_ORB_DOT_COUNT)
+    expect(NOVA_WORKING_MESSAGES).toContain(copy?.textContent as typeof NOVA_WORKING_MESSAGES[number])
+    expect(pending?.querySelector('.assistant-pending__label')?.textContent).toBe('正在思考')
+
+    renderer.unmount()
+  })
+})

--- a/tests/unit/renderer/assistantPendingIndicator.test.ts
+++ b/tests/unit/renderer/assistantPendingIndicator.test.ts
@@ -1,16 +1,24 @@
 // @vitest-environment jsdom
 
 import React from 'react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   AssistantPendingIndicator,
   NOVA_WORKING_MESSAGES,
   pickNonRepeatingWorkingMessage
 } from '../../../src/renderer/features/chat/AssistantPendingIndicator'
 import { NOVA_WORKING_ORB_DOT_COUNT } from '../../../src/renderer/features/chat/NovaWorkingOrb'
-import { renderDom } from './renderDom'
+import { act, renderDom } from './renderDom'
 
 describe('AssistantPendingIndicator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('工作文案保持 10 条，并保证下一条不会和上一条重复', () => {
     expect(NOVA_WORKING_MESSAGES).toHaveLength(10)
 
@@ -31,6 +39,13 @@ describe('AssistantPendingIndicator', () => {
     expect(orb?.querySelectorAll('.nova-working-orb__dot')).toHaveLength(NOVA_WORKING_ORB_DOT_COUNT)
     expect(NOVA_WORKING_MESSAGES).toContain(copy?.textContent as typeof NOVA_WORKING_MESSAGES[number])
     expect(pending?.querySelector('.assistant-pending__label')?.textContent).toBe('正在思考')
+
+    act(() => vi.advanceTimersByTime(1500))
+    expect(orb?.getAttribute('data-shape')).toBe('O')
+    act(() => vi.advanceTimersByTime(1500))
+    expect(orb?.getAttribute('data-shape')).toBe('V')
+    act(() => vi.advanceTimersByTime(1500))
+    expect(orb?.getAttribute('data-shape')).toBe('A')
 
     renderer.unmount()
   })


### PR DESCRIPTION
## 变化

Nova 在一轮 Agent 执行尚未结束时持续展示轻量工作状态，让用户能明确知道它仍在处理当前任务。

- 首个内容出现前、思考、工具调用和正文输出过程中，工作状态保持同一条反馈，不会因内容开始出现而重置。
- 等待用户输入、权限确认或其他交互时自动隐藏，避免造成仍在执行的误解。
- 使用淡紫色点阵在 `N → O → V → △` 之间循环变形，并带轻微呼吸微光，适配 Electron 的深浅背景。
- 10 条 Nova 风格工作文案随机轮播，相邻两条不会重复。
- 多窗口、多会话实例各自拥有自己的文案轮播状态，不共享可变全局状态。
- 保留当前 `dev` 中思考耗时持久化和流式淡入等聊天体验改动。
- 支持 `prefers-reduced-motion`，读屏器使用稳定状态文案，不随视觉彩蛋反复播报。

## 边界

改动只位于 Renderer 的聊天展示层，不触碰 Agent kernel、运行时协议、持久化或公共数据契约。工作文案状态由当前工作状态实例独立持有，没有新增跨模块状态或第二份真源。

## 验证

新增单元测试覆盖 10 条文案、相邻不重复、多个实例状态隔离、24 粒子数量和 `N → O → V → △` 循环。分支已同步当前 `dev`，共享的消息渲染文件以当前 `dev` 版本为基础，只保留工作状态所需的最小差异。

当前 GitHub 连接环境无法启动 Electron，也无法执行本地 `npm run typecheck`、Vitest 与仓库门禁，因此没有把静态审查冒充为本地测试结果。合并前请在本地运行这些门禁并实际查看深色、浅色主题下的动效。历史中已有的细碎提交建议在合并时使用 squash，保持 `dev` 历史为单条产品更新说明。