### PR TITLE
fix(ci): 长会话质量门禁与大结果归档策略对齐

### DIFF
--- a/tests/unit/main/agent/messageFacts.test.ts
+++ b/tests/unit/main/agent/messageFacts.test.ts
@@ -25,6 +25,11 @@ import { toSharedMessage } from '../../../../src/main/ipc/sessionMessageMapper'
 import { toRendererRunSnapshot } from '../../../../src/shared/run/rendererProjection'
 import { forwardEventToRenderer } from '../../../../src/main/agent/events/AgentEventForwarder'
 import type { MessageContext } from '../../../../src/main/agent/events/types'
+import {
+  ACTIVE_TOOL_RESULT_MAX_TOKENS,
+  CHARS_PER_TOKEN,
+  isArchivedPlaceholder
+} from '../../../../src/runtime/request-projection'
 
 let sessionStore: SessionStore
 let coordinator: RunCoordinator
@@ -41,6 +46,15 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
 })
 const hash = (s: string) => createHash('sha256').update(s).digest('hex')
+type WireMessage = { role: string; content?: unknown; tool_call_id?: string; [key: string]: unknown }
+const asWire = (messages: unknown[]) => messages as WireMessage[]
+const wireTool = (messages: unknown[], id: string) =>
+  asWire(messages).find(message => message.role === 'tool' && message.tool_call_id === id)
+const wireBeforeTool = (messages: unknown[], id: string) => {
+  const list = asWire(messages)
+  const index = list.findIndex(message => message.role === 'tool' && message.tool_call_id === id)
+  return index === -1 ? list : list.slice(0, index)
+}
 
 function setup() {
   const root = mkdtempSync(join(tmpdir(), 'nova-message-facts-'))
@@ -168,10 +182,23 @@ describe('消息事实提交往返', () => {
     expect((await restored.sendMessage('下一题', agentRoute())).status).toBe('completed')
     expect(sessionStore.loadContextSnapshot(session.id)?.revision).toBe(4)
     const next = bodies.at(-1)!
-    expect(bodies[2].messages.slice(0, bodies[1].messages.length)).toEqual(bodies[1].messages)
     const prefix = next.messages.slice(0, previous.messages.length)
+    const oversize = size > ACTIVE_TOOL_RESULT_MAX_TOKENS * CHARS_PER_TOKEN
+    const fullTool = '中'.repeat(size)
     console.info(JSON.stringify({ previousCount: previous.messages.length, nextCount: next.messages.length, previousHash: hash(JSON.stringify(previous.messages)), restoredPrefixHash: hash(JSON.stringify(prefix)), envelopeEqual: JSON.stringify({ ...previous, messages: null }) === JSON.stringify({ ...next, messages: null }) }))
-    expect(JSON.stringify(prefix)).toBe(JSON.stringify(previous.messages))
+    if (oversize) {
+      // 超阈值结果先全文投递一轮，下一请求换成可回读占位符；断点前的前缀仍逐字节一致。
+      expect(wireTool(bodies[1].messages, 't1')?.content).toBe(fullTool)
+      expect(isArchivedPlaceholder(String(wireTool(bodies[2].messages, 't1')?.content))).toBe(true)
+      expect(wireTool(bodies[2].messages, 't2')?.content).toBe(fullTool)
+      expect(wireBeforeTool(bodies[2].messages, 't1')).toEqual(wireBeforeTool(bodies[1].messages, 't1'))
+      expect(wireTool(next.messages, 't1')?.content).toBe(wireTool(previous.messages, 't1')?.content)
+      expect(isArchivedPlaceholder(String(wireTool(next.messages, 't2')?.content))).toBe(true)
+      expect(wireBeforeTool(next.messages, 't2')).toEqual(wireBeforeTool(previous.messages, 't2'))
+    } else {
+      expect(bodies[2].messages.slice(0, bodies[1].messages.length)).toEqual(bodies[1].messages)
+      expect(JSON.stringify(prefix)).toBe(JSON.stringify(previous.messages))
+    }
     expect({ ...next, messages: null }).toEqual({ ...previous, messages: null })
   })
   it.each(['x'.repeat(8035), 'y'.repeat(12000), '中文🙂'.repeat(2500)])('完整事件经过草稿和正式存储保留工具正文 %#', async (body) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 失败了什么

Quality Gate 的 `verify` job 固定死在 **Vitest regression**，typecheck / 依赖安装都是绿的。后面的 production build 和 Electron 步骤因此被跳过。

最新失败（Quality Gate #89，`e4e16d7`，以及 #88 `6fce585`、`main` 上的 `b2de69b`）都是同一条用例：

`tests/unit/main/agent/messageFacts.test.ts` → `新建 loop 从真实提交恢复后保持完整已发 wire 前缀 12000 / image=false / skill=false`

期望：恢复会话后再发一条消息，已发出去的请求前缀与上一轮最后一次请求逐字节相同。

实际：上一轮已经给模型看过的超长工具结果，在下一请求里被换成了 `nova.archived_tool_result` 可回读占位符（`reason: consumed_then_archived`）。

## 为什么几乎每次提交都红

这不是 runner、密钥或路径大小写问题，也不是偶发超时。Node 20 deprecation 和 `git.exe` exit 128 只是警告，不是失败原因。

从 `feat(context): 大段工具结果先完整给模型看一轮，再归档`（`b2de69b`）起，体积超过归档阈值（2048 token / 约 8192 字符）的工具结果会在**看过一轮之后**归档。这条策略是产品行为，相关契约已经写在 `prefixCacheStability` / `toolDeliveryTiming` 里。

但 `messageFacts` 这条 12000 字中文用例仍按旧约定断言「恢复后全文前缀不变」。12000 > 8192，所以：

- 在 Windows CI 和 Linux 本地都会必现失败
- 阈值以下的 8035 / 带图片的 50 字用例仍然通过
- 因此从那次上下文改动之后，推到 `dev` / `main` 的提交都会被这一条单测挡住

最后一次全绿是归档策略落地之前的 `b891539`。

## 改了什么

没有削弱 Quality Gate，也没有改归档实现。

恢复会话的回归改为与现有归档契约一致：

- **超过阈值**：确认第一轮仍发全文；下一请求换成稳定占位符；占位符之前的前缀仍逐字节一致；恢复后再发时已归档的结果保持同一占位符
- **未超过阈值**：行为不变，仍要求整段已发前缀全文一致（技能历史、小结果、图片请求）

权威会话存储里的工具正文仍然保留全文，这条路径的既有测试未改。

## 验证

本 PR 上的 Quality Gate 已通过：https://github.com/iZiTTMarvin/Nova-agent/actions/runs/34598739117

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30a80ba6-bade-4bf4-bf1c-4ebd94c53b0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30a80ba6-bade-4bf4-bf1c-4ebd94c53b0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

